### PR TITLE
More general homotopies

### DIFF
--- a/src/HomConBase/HomConBase.jl
+++ b/src/HomConBase/HomConBase.jl
@@ -3,13 +3,13 @@ module HomConBase
     #using Reexport
     import Base: eltype, gradient
 
-    import FixedPolySystem: Poly, PolySystem,
+    import FixedPolySystem: AbstractPolySystem, Poly, PolySystem,
         nvariables, variables, polynomials, degrees,
         evaluate, evaluate!, differentiate,
         ishomogenous, homogenize, homogenized, dehomogenize,
         weyldot, weylnorm
     # Exports from FixedPolySystem
-    export Poly, PolySystem,
+    export AbstractPolySystem, Poly, PolySystem,
         nvariables, variables, polynomials, degrees,
         evaluate, evaluate!, differentiate,
         ishomogenous, homogenize, homogenized, dehomogenize,

--- a/src/Homotopy/Homotopy.jl
+++ b/src/Homotopy/Homotopy.jl
@@ -10,8 +10,9 @@ module Homotopy
     import Base: length
     include("straight_line.jl")
     include("gamma_trick.jl")
+    include("fixedhomotopy.jl")
 
     export evaluate, startsystem, targetsystem, differentiate,
         dt, homogenize, homogenized, degrees, weylnorm, nvars, nequations
-    export StraightLineHomotopy, GammaTrickHomotopy
+    export StraightLineHomotopy, GammaTrickHomotopy, FixedHomotopy
 end

--- a/src/Homotopy/Homotopy.jl
+++ b/src/Homotopy/Homotopy.jl
@@ -1,7 +1,7 @@
 module Homotopy
 
     using ..HomConBase
-    import ..HomConBase: AbstractHomotopy, evaluate,
+    import ..HomConBase: AbstractHomotopy, AbstractPolySystem, evaluate,
         startsystem, targetsystem,
         differentiate, dt,
         homogenize, ishomogenous, homogenized,

--- a/src/Homotopy/fixedhomotopy.jl
+++ b/src/Homotopy/fixedhomotopy.jl
@@ -1,0 +1,34 @@
+"""
+    FixedHomotopy(homotopy, t)
+
+Fix the homotopy at `t`, i.e. consider ``H(x,t)`` as ``H(x)``
+"""
+struct FixedHomotopy{T<:Number, H<:AbstractHomotopy{T}, S<:Number} <: AbstractPolySystem{T}
+    homotopy::H
+    t::S
+end
+function FixedHomotopy(hom::H, t::S) where {T<:Number, H<:AbstractHomotopy{T}, S<:Number}
+    FixedHomotopy{T, H, S}(hom, t)
+end
+
+@inline evaluate(H::FixedHomotopy, x) = evaluate(H.homotopy, x, H.t)
+(H::FixedHomotopy)(x) = evaluate(H,x)
+
+function Base.show(io::IO, H::FixedHomotopy)
+    print(io, typeof(H), ":\n")
+    println(io, "* homotopy:")
+    println(io, H.homotopy)
+    println(io, "* t: ", H.t)
+end
+function differentiate(H::FixedHomotopy)
+    dh = differentiate(H.homotopy)
+    (x) -> dh(x, H.t)
+end
+
+homogenize(H::FixedHomotopy) = FixedHomotopy(homogenize(H.homotopy), H.t)
+homogenized(H::FixedHomotopy) = homogenized(H.homotopy)
+ishomogenous(H::FixedHomotopy) = ishomogenous(H.homotopy)
+nvariables(H::FixedHomotopy) = nvariables(H.homotopy)
+degrees(H::FixedHomotopy) = degrees(H.homotopy)
+
+Base.length(H::FixedHomotopy) = length(H.homotopy)

--- a/src/Homotopy/gamma_trick.jl
+++ b/src/Homotopy/gamma_trick.jl
@@ -9,12 +9,12 @@ This yields a more generic interpolation.
 
 Possible to create it optionally with a seed.
 """
-struct GammaTrickHomotopy{T<:Number} <: AbstractHomotopy{T}
-    start::PolySystem{T}
-    target::PolySystem{T}
+struct GammaTrickHomotopy{T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}} <: AbstractHomotopy{T}
+    start::Start
+    target::Target
     γ::Complex128
 
-    function GammaTrickHomotopy{T}(start::PolySystem{T}, target::PolySystem{T}, γ::Complex128) where {T<:Number}
+    function GammaTrickHomotopy{T, Start, Target}(start::AbstractPolySystem{T}, target::AbstractPolySystem{T}, γ::Complex128) where {T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}}
         if (homogenized(start) != homogenized(target))
             return error("start and target have to be both either homogenized or not")
         end
@@ -34,11 +34,11 @@ struct GammaTrickHomotopy{T<:Number} <: AbstractHomotopy{T}
     end
 end
 
-function GammaTrickHomotopy(start::PolySystem{T},target::PolySystem{T}, γ::Complex128) where {T<:Number}
-    GammaTrickHomotopy{T}(start,target,γ)
+function GammaTrickHomotopy(start::Start,target::Target, γ::Complex128) where {T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}}
+    GammaTrickHomotopy{T, Start, Target}(start,target,γ)
 end
 # promote if they don't have the same coefficients
-function GammaTrickHomotopy(start::PolySystem,target::PolySystem, γ::Complex128)
+function GammaTrickHomotopy(start::AbstractPolySystem,target::AbstractPolySystem, γ::Complex128)
     s, t = promote(start, target)
     GammaTrickHomotopy(s, t, γ)
 end

--- a/src/Homotopy/straight_line.jl
+++ b/src/Homotopy/straight_line.jl
@@ -1,13 +1,13 @@
 """
-    StraightLineHomotopy(start::PolySystem, target::PolySystem)
+    StraightLineHomotopy(start::AbstractPolySystem, target::AbstractPolySystem)
 
 Constructs the homotopy `t * start + (1-t) * target`.
 """
-struct StraightLineHomotopy{T<:Number} <: AbstractHomotopy{T}
-    start::PolySystem{T}
-    target::PolySystem{T}
+struct StraightLineHomotopy{T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}} <: AbstractHomotopy{T}
+    start::Start
+    target::Target
 
-    function StraightLineHomotopy{T}(start::PolySystem{T}, target::PolySystem{T}) where {T<:Number}
+    function StraightLineHomotopy{T, Start, Target}(start::Start, target::Target) where {T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}}
         if (homogenized(start) != homogenized(target))
             return error("start and target have to be both either homogenized or not")
         end
@@ -27,11 +27,11 @@ struct StraightLineHomotopy{T<:Number} <: AbstractHomotopy{T}
     end
 end
 
-function StraightLineHomotopy(start::PolySystem{T},target::PolySystem{T}) where {T<:Number}
-    StraightLineHomotopy{T}(start,target)
+function StraightLineHomotopy(start::Start,target::Target) where {T<:Number, Start<:AbstractPolySystem{T}, Target<:AbstractPolySystem{T}}
+    StraightLineHomotopy{T, Start, Target}(start,target)
 end
 # promote if they don't have the same coefficients
-function StraightLineHomotopy(start::PolySystem,target::PolySystem)
+function StraightLineHomotopy(start::AbstractPolySystem,target::AbstractPolySystem)
     s, t = promote(start, target)
     StraightLineHomotopy(s, t)
 end

--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -25,7 +25,7 @@ module HomotopyContinuation
     # Homotopy Exports
     export evaluate, startsystem, targetsystem, differentiate,
         dt, homogenize, homogenized, degrees, weylnorm, nvars, nequations
-    export StraightLineHomotopy, GammaTrickHomotopy
+    export StraightLineHomotopy, GammaTrickHomotopy, FixedHomotopy
 
 
     include("PredictorCorrector/PredictorCorrector.jl")

--- a/test/fixedhomotopy_test.jl
+++ b/test/fixedhomotopy_test.jl
@@ -1,0 +1,34 @@
+@testset "FixedHomotopy" begin
+    PolyImpl.@polyvar x y a
+    H = StraightLineHomotopy([y^2-x], [x^2+3.0y])
+
+    H1 = FixedHomotopy(H, 1.0)
+    H0 = FixedHomotopy(H, 0.0)
+    HH = StraightLineHomotopy(H1, H0)
+
+    @test typeof(H1)<:FixedHomotopy{Float64, typeof(H), Float64}
+
+    @test evaluate(H1, [2.0, 1.0]) == evaluate(H, [2.0, 1.0], 1.0)
+    @test H1([2.0, 1.0]) == H([2.0, 1.0], 1.0)
+    @test H0([2.0, 1.0]) == H([2.0, 1.0], 0.0)
+    @test HH([2.0, 1.0], 1.0) == H([2.0, 1.0], 1.0)
+    @test HH([2.0, 1.0], 0.0) == H([2.0, 1.0], 0.0)
+
+    J_H = differentiate(H)
+    J_H1 = differentiate(H1)
+    J_H0 = differentiate(H0)
+
+    @test J_H0([1.0, 1.0]) == J_H([1.0, 1.0], 0.0)
+    @test J_H1([1.0, 1.0]) == J_H([1.0, 1.0], 1.0)
+
+    @test degrees(H1) == [2]
+
+    H = FixedHomotopy(StraightLineHomotopy([y^2-x, 3x + y], [x^2+3y, 2y-3x]), 0.34)
+
+    @test homogenized(H) == false
+    K = homogenize(H)
+    @test ishomogenous(H) == false
+    @test homogenized(K)
+    @test ishomogenous(K)
+    @test nvariables(K) == 3
+end

--- a/test/gamma_trick_test.jl
+++ b/test/gamma_trick_test.jl
@@ -3,7 +3,7 @@
     PolyImpl.@polyvar x y
 
     H = GammaTrickHomotopy([y^2-x], [x^2+3y], 1.0+0im)
-    @test typeof(H)<:GammaTrickHomotopy{Int64}
+    @test typeof(H)<:GammaTrickHomotopy{Int64, PolySystem{Int64}, PolySystem{Int64}}
 
     @test evaluate(H, [2.0+0im, 1.0], 1.0) == [-1.0+0im]
     @test H([2.0+0im, 1.0], 1.0) == [-1.0+0im]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("base_utilities_test.jl")
 
 include("straight_line_test.jl")
 include("gamma_trick_test.jl")
+include("fixedhomotopy_test.jl")
 include("spherical_test.jl")
 include("affine_test.jl")
 include("test_systems_test.jl")

--- a/test/straight_line_test.jl
+++ b/test/straight_line_test.jl
@@ -1,7 +1,7 @@
 @testset "StraightLineHomotopy" begin
     PolyImpl.@polyvar x y a
     H = StraightLineHomotopy([y^2-x], [x^2+3.0y])
-    @test typeof(H)<:StraightLineHomotopy{Float64}
+    @test typeof(H)<:StraightLineHomotopy{Float64, PolySystem{Float64}, PolySystem{Float64}}
     @test_throws ErrorException StraightLineHomotopy([x^2+3.1y], [a])
     @test_throws ErrorException StraightLineHomotopy([x^2+3y, y^2-x], [x^2+3y])
 


### PR DESCRIPTION
Sometimes you want to consider a homotopy `H(x,t)` actually as a system of polynomials `H(x;t0)`, where `t0` is a constant. Previously we would have to generate a whole new homotopy for that.
This introduces `FixedHomotopy` to solve this issue. FixedHomotopy takes a homotopy and a time t and acts like a system of polynomials. This enables to compose a homotopy out of multiple homotopies.

Example:
```julia
F = PolySystem([x^2-1, y^2-1])
G = PolySystem([x^2-y, y^2-x])
H = StraightLineHomotopy(G, F)

H0 = FixedHomotopy(H, 0.0)
H1 = FixedHomotopy(H, 1.0)

HH = StraightLineHomotopy(H1, H0)
# Now we have H(x,t) == HH(x,t) for all x and t
```